### PR TITLE
feat: added macos compatibility and installation support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ Thanks for your interest. A few ground rules keep this project simple, private, 
   named, allowlisted metadata fields, never raw prompt or response text. Do not add a code
   path that reads transcript content outside that adapter, or that forwards a message body
   to the client. This is the whole reason the console is safe to run.
-- **Windows-first.** The launchers (`.cmd`, `.vbs`), the always-on Scheduled Task, and the
-  installer target Windows and PowerShell 5.1. Keep them working. Cross-platform support is
-  welcome as long as it does not break the Windows path.
+- **Windows and macOS.** Keep both installers and launchers working:
+  Windows (`.ps1`, `.cmd`, `.vbs`, Scheduled Task) and macOS (`.sh`, LaunchAgent). Do not
+  break one platform to improve the other.
 - **House style.** Match the terse voice of the existing agents and code. No em or en
   dashes in prose or comments; use commas, periods, or hyphens. Comments explain WHY, not
   WHAT.
@@ -21,11 +21,13 @@ Thanks for your interest. A few ground rules keep this project simple, private, 
 ## Before you open a PR
 
 - Run `node --check` on every `.mjs` / `.js` file you touched.
-- If you changed the console, run it (`console\restart.cmd`) and confirm the affected view
-  still renders in the browser.
+- If you changed the console, run it (`console\restart.cmd` on Windows, or
+  `console/stop.sh` then `console/start.sh` on macOS) and confirm the affected view still
+  renders in the browser.
 - If you changed an agent, the skill, or a template token, run
-  `install.ps1 -ClaudeDir <scratch> -NoConsole` into a throwaway folder and confirm every
-  `{{TOKEN}}` resolved and nothing personal leaked in.
+  `install.ps1 -ClaudeDir <scratch> -NoConsole` (Windows) or
+  `./install.sh --claude-dir <scratch> --no-console` (macOS) into a throwaway folder and
+  confirm every `{{TOKEN}}` resolved and nothing personal leaked in.
 - Never commit a `*.local.json`, a `.credentials.json`, an `.env`, or any real path from
   your own machine. `.gitignore` guards the common cases; you are still responsible.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <img src="https://img.shields.io/badge/JavaScript-F7DF1E?logo=javascript&logoColor=black" alt="JavaScript">
   <img src="https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/PowerShell-5391FE?logo=powershell&logoColor=white" alt="PowerShell">
+  <img src="https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=white" alt="Bash">
+  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-111111?logo=apple&logoColor=white" alt="macOS and Windows">
   <img src="https://img.shields.io/badge/HTML5-E34F26?logo=html5&logoColor=white" alt="HTML5">
   <img src="https://img.shields.io/badge/CSS3-1572B6?logo=css3&logoColor=white" alt="CSS3">
 </p>
@@ -69,10 +71,13 @@ conversation (and in the Comms feed).
 
 ---
 
-## Quickstart (Windows)
+## Quickstart
 
-Requirements: **Windows 10/11**, **PowerShell 5.1+**, **Node 20+** (Node 26 recommended),
-and **[Claude Code](https://claude.com/claude-code)** already installed and signed in.
+Requirements: **Windows 10/11** or **macOS**, **Node 20+** (Node 26 recommended), and
+**[Claude Code](https://claude.com/claude-code)** already installed and signed in.
+Windows also needs **PowerShell 5.1+**.
+
+**Windows**
 
 ```powershell
 git clone https://github.com/Sdraugel/albert.git
@@ -80,11 +85,21 @@ cd albert
 powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
+**macOS**
+
+```bash
+git clone https://github.com/Sdraugel/albert.git
+cd albert
+chmod +x install.sh uninstall.sh
+./install.sh
+```
+
 The installer copies the harness (the `/albert` skill, the agent roster, the parallel
 executor, and the event emitter) into your Claude Code config, resolves every machine-path
 template token to your own home directory, and offers to register the console as an
-always-on background task. Nothing personal from the author's machine is shipped or
-installed; the installer generates everything from your environment.
+always-on background service (Windows Scheduled Task, or a macOS LaunchAgent). Nothing
+personal from the author's machine is shipped or installed; the installer generates
+everything from your environment.
 
 Then, in any Claude Code session inside a project you want worked on:
 
@@ -94,13 +109,20 @@ Then, in any Claude Code session inside a project you want worked on:
 
 Open the console at **http://localhost:4400** and watch it run.
 
-Optional, to talk to the orchestrator from the console (requires **Python 3.12** via the
-`py` launcher):
+Optional, to talk to the orchestrator from the console (requires **Python 3.12**):
 
 ```powershell
+# Windows
 cd chat
-.\setup.cmd     # one-time: builds the venv and installs Chainlit + the Claude Agent SDK
-.\start.cmd     # serves the chat on 127.0.0.1:4401
+.\setup.cmd
+.\start.cmd
+```
+
+```bash
+# macOS
+cd chat
+./setup.sh
+./start.sh
 ```
 
 Then hit the **CHAT** button in the console's nav rail. Details and caveats are in
@@ -110,13 +132,25 @@ To try the UI before you run anything real, boot it against the bundled syntheti
 data:
 
 ```powershell
+# Windows
 powershell -ExecutionPolicy Bypass -File .\install.ps1 -DemoOnly
+```
+
+```bash
+# macOS
+./install.sh --demo-only
 ```
 
 To remove everything:
 
 ```powershell
+# Windows
 powershell -ExecutionPolicy Bypass -File .\uninstall.ps1
+```
+
+```bash
+# macOS
+./uninstall.sh
 ```
 
 ---

--- a/chat/README.md
+++ b/chat/README.md
@@ -18,15 +18,18 @@ survives closing the chat.
 
 ## Prerequisites
 
-- Windows, with the Albert harness installed (`install.ps1` from the repo root; it deploys
-  `_inbox.mjs` into the run store).
-- **Python 3.12** available as `py -3.12` (the default `python` may be newer than Chainlit
-  supports; setup builds the venv from 3.12 explicitly).
+- Windows or macOS, with the Albert harness installed (`install.ps1` or `install.sh` from
+  the repo root; it deploys `_inbox.mjs` into the run store).
+- **Python 3.12** (`py -3.12` on Windows, or `python3.12` / Homebrew `python@3.12` on
+  macOS). The default `python` may be newer than Chainlit supports; setup builds the venv
+  from 3.12 explicitly.
 - Node on PATH (the harness already requires it).
 - Claude Code installed and logged in. The concierge inherits that login; no API key is
   needed or read.
 
 ## Setup and run
+
+**Windows**
 
 ```
 setup.cmd      # one-time: creates .venv from Python 3.12 and installs requirements
@@ -34,10 +37,19 @@ start.cmd      # serves http://127.0.0.1:4401 and opens the browser (foreground)
 stop.cmd       # kills whatever owns port 4401
 ```
 
-`start.cmd` runs in the foreground: closing that window stops the chat. For an always-on
-chat (so the console's CHAT dock is always live), point an HKCU Run entry at
-`run-forever.vbs`, which starts the server hidden at logon and relaunches it within
-seconds if it dies:
+**macOS**
+
+```
+./setup.sh     # one-time: creates .venv from Python 3.12 and installs requirements
+./start.sh     # serves http://127.0.0.1:4401 and opens the browser (foreground)
+./stop.sh      # kills whatever owns port 4401
+```
+
+`start.cmd` / `start.sh` run in the foreground: closing that window stops the chat.
+
+On Windows, for an always-on chat (so the console's CHAT dock is always live), point an
+HKCU Run entry at `run-forever.vbs`, which starts the server hidden at logon and relaunches
+it within seconds if it dies:
 
 ```powershell
 Set-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name AlbertChat `
@@ -45,7 +57,7 @@ Set-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name Alb
 ```
 
 `stop.cmd` kills the supervisor and the server together (a plain port kill is not enough;
-the supervisor would relaunch it).
+the supervisor would relaunch it). On macOS, `stop.sh` frees port 4401 directly.
 
 Resolved versions this was built and tested against: Python 3.12.6, chainlit 2.11.1,
 claude-agent-sdk 0.2.126.
@@ -58,9 +70,9 @@ claude-agent-sdk 0.2.126.
 
 ## Configuration (env vars, all optional)
 
-- `ALBERT_STORE_ROOT` - run store root (default `%USERPROFILE%\.claude\agent-runs`). Point it
-  at demo data (`node tools\make-demo-data.mjs <out>` then `<out>\agent-runs`) to try the UI
-  without real runs.
+- `ALBERT_STORE_ROOT` - run store root (default `~/.claude/agent-runs`). Point it at demo
+  data (`node tools/make-demo-data.mjs <out>` then `<out>/agent-runs`) to try the UI without
+  real runs.
 - `ALBERT_PROJECTS_DIR` - where `start_albert_run` may launch runs (default: the parent
   directory of this repo, same as the installer's default).
 - `ALBERT_INBOX_MJS` - path to `_inbox.mjs` (default: the installed copy in the store;

--- a/chat/albert_tools.py
+++ b/chat/albert_tools.py
@@ -1,14 +1,16 @@
 """Custom tools for the Albert concierge: the only two write paths out of the chat.
 
 Both tools shell out rather than touching the store from Python: send_to_albert goes
-through _inbox.mjs (which owns the NTFS write discipline), and start_albert_run goes
-through launch_run.ps1 (which owns .cmd resolution and detached-window quoting).
+through _inbox.mjs (which owns the store write discipline), and start_albert_run goes
+through launch_run.ps1 (Windows) or launch_run.sh (macOS/Unix), which own detached-window
+quoting and CLI resolution.
 """
 
 import asyncio
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -16,7 +18,7 @@ from claude_agent_sdk import create_sdk_mcp_server, tool
 
 from config import (
     INBOX_MJS,
-    LAUNCH_PS1,
+    LAUNCH_SCRIPT,
     PROJECTS_DIR,
     STORE_ROOT,
     TERMINAL_STATUSES,
@@ -195,26 +197,36 @@ def make_albert_server(state: SessionState):
                 is_error=True,
             )
 
-        # The goal ends up on a command line whose target is an npm .cmd shim, so
-        # cmd.exe gets a second crack at parsing it. Collapse whitespace, then drop
-        # every character that shim could act on (see CMD_METACHARACTERS); quoting
-        # alone is not a sufficient defense across that boundary.
+        # The goal ends up on a command line (Windows npm .cmd shim via cmd.exe, or a
+        # shell on macOS). Collapse whitespace, then drop every character those shells
+        # could act on (see CMD_METACHARACTERS); quoting alone is not a sufficient
+        # defense across that boundary.
         goal = CMD_METACHARACTERS.sub(" ", re.sub(r"\s+", " ", goal)).strip()
         if not goal:
             return _text("goal became empty after removing unsafe characters.", is_error=True)
         prompt = f"/loop /albert {goal}"
-        cmd = [
-            "powershell",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            str(LAUNCH_PS1),
-            "-Project",
-            str(project),
-            "-Prompt",
-            prompt,
-        ]
+        if sys.platform == "win32":
+            cmd = [
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(LAUNCH_SCRIPT),
+                "-Project",
+                str(project),
+                "-Prompt",
+                prompt,
+            ]
+        else:
+            cmd = [
+                "bash",
+                str(LAUNCH_SCRIPT),
+                "--project",
+                str(project),
+                "--prompt",
+                prompt,
+            ]
         try:
             proc = await asyncio.to_thread(_run, cmd)
         except (OSError, subprocess.TimeoutExpired) as e:

--- a/chat/config.py
+++ b/chat/config.py
@@ -1,15 +1,16 @@
 """Shared paths and store helpers for Albert Chat.
 
 Env overrides (all optional, mainly for tests against demo data):
-  ALBERT_STORE_ROOT    run store root (default: %USERPROFILE%\\.claude\\agent-runs)
+  ALBERT_STORE_ROOT    run store root (default: ~/.claude/agent-runs)
   ALBERT_PROJECTS_DIR  where start_albert_run may launch runs (default: parent of this repo,
-                       matching install.ps1's ProjectsDir default)
+                       matching the installer's ProjectsDir default)
   ALBERT_INBOX_MJS     path to _inbox.mjs (default: the installed copy in the store dir,
                        falling back to the repo copy)
 """
 
 import json
 import os
+import sys
 from pathlib import Path
 
 CHAT_DIR = Path(__file__).resolve().parent
@@ -25,7 +26,10 @@ if not INBOX_MJS.exists():
     if _repo_copy.exists():
         INBOX_MJS = _repo_copy
 
-LAUNCH_PS1 = CHAT_DIR / "launch_run.ps1"
+# Windows keeps the PowerShell launcher (npm .cmd shim + Start-Process); macOS/Unix
+# use the bash counterpart that opens Terminal.app / nohup.
+LAUNCH_SCRIPT = CHAT_DIR / ("launch_run.ps1" if sys.platform == "win32" else "launch_run.sh")
+LAUNCH_PS1 = LAUNCH_SCRIPT  # backward-compatible alias
 SYSTEM_PROMPT_PATH = CHAT_DIR / "system_prompt.md"
 
 # A message sent to a run in one of these states would sit in the inbox forever:

--- a/chat/launch_run.sh
+++ b/chat/launch_run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Launch a detached, visible Claude Code session running an /albert goal.
+#
+# Invoked by the chat backend as:
+#   bash launch_run.sh --project <dir> --prompt <text>
+#
+# On macOS this opens a new Terminal.app window (mirrors Windows Start-Process).
+# The prompt must not contain double quotes (the caller strips them).
+set -euo pipefail
+
+PROJECT=""
+PROMPT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2 ;;
+    --prompt)  PROMPT="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$PROJECT" && -n "$PROMPT" ]] || { echo "usage: $0 --project DIR --prompt TEXT" >&2; exit 1; }
+[[ -d "$PROJECT" ]] || { echo "project directory not found: $PROJECT" >&2; exit 1; }
+[[ "$PROMPT" != *\"* ]] || { echo 'prompt must not contain double quotes' >&2; exit 1; }
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI not found on PATH" >&2
+  exit 1
+fi
+
+# Escape for embedding inside an AppleScript double-quoted string.
+as_escape() {
+  # backslash, then double-quote
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '%s' "$s"
+}
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v osascript >/dev/null 2>&1; then
+  proj_q="$(as_escape "$PROJECT")"
+  prompt_q="$(as_escape "$PROMPT")"
+  osascript <<EOF
+tell application "Terminal"
+  do script "cd \"${proj_q}\" && claude \"${prompt_q}\""
+  activate
+end tell
+EOF
+  exit 0
+fi
+
+# Non-macOS Unix fallback: detached process, no new terminal UI.
+(
+  cd "$PROJECT"
+  nohup claude "$PROMPT" >/dev/null 2>&1 &
+)
+echo "launched claude in background under $PROJECT"

--- a/chat/setup.sh
+++ b/chat/setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# One-time setup for Albert Chat. Requires Python 3.12.
+# The venv is built from 3.12 explicitly: the default python may be newer than
+# Chainlit supports.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV="$DIR/.venv"
+
+pick_python() {
+  if command -v python3.12 >/dev/null 2>&1; then
+    echo "python3.12"
+    return
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    local ver
+    ver="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    if [[ "$ver" == "3.12" ]]; then
+      echo "python3"
+      return
+    fi
+  fi
+  return 1
+}
+
+if [[ ! -x "$VENV/bin/python" ]]; then
+  py="$(pick_python)" || {
+    echo "Python 3.12 not found: install it (e.g. brew install python@3.12), then re-run." >&2
+    exit 1
+  }
+  "$py" -m venv "$VENV"
+fi
+
+"$VENV/bin/python" -c 'import sys; raise SystemExit(0 if sys.version_info[:2]==(3,12) else 1)' || {
+  echo "chat/.venv is not Python 3.12. Delete it and re-run setup.sh." >&2
+  exit 1
+}
+
+"$VENV/bin/python" -m pip install --disable-pip-version-check -r "$DIR/requirements.txt"
+echo
+echo "Done. Start the chat UI with ./start.sh"

--- a/chat/start.sh
+++ b/chat/start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Albert Chat on http://127.0.0.1:4401. Runs in the foreground: closing this
+# terminal stops it.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+[[ -x "$DIR/.venv/bin/python" ]] || { echo "Run ./setup.sh first." >&2; exit 1; }
+
+if command -v open >/dev/null 2>&1; then
+  (sleep 2; open "http://127.0.0.1:4401/") &
+elif command -v xdg-open >/dev/null 2>&1; then
+  (sleep 2; xdg-open "http://127.0.0.1:4401/") &
+fi
+
+# Served through server.py, NOT `chainlit run`: it adds the Origin guard that stops
+# any page you happen to be browsing from hijacking the chat's WebSocket.
+cd "$DIR"
+exec "$DIR/.venv/bin/python" -m uvicorn server:app --host 127.0.0.1 --port 4401 "$@"

--- a/chat/stop.sh
+++ b/chat/stop.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Stop Albert Chat: kill whatever owns port 4401.
+set -euo pipefail
+PORT=4401
+pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+if [[ -n "$pids" ]]; then
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  sleep 0.3
+  pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill -9 $pids 2>/dev/null || true
+  fi
+  echo "chat stopped"
+else
+  echo "chat was not running"
+fi

--- a/console/README.md
+++ b/console/README.md
@@ -1,18 +1,22 @@
 # Albert Console
 
-A live, Jarvis-style console for the `/albert` harness. It watches the global run store at `%USERPROFILE%\.claude\agent-runs\` and monitors ALL projects' runs from one place. Zero npm dependencies (Node builtins only), binds to 127.0.0.1 only.
+A live, Jarvis-style console for the `/albert` harness. It watches the global run store at
+`~/.claude/agent-runs/` and monitors ALL projects' runs from one place. Zero npm dependencies
+(Node builtins only), binds to 127.0.0.1 only.
 
 **Strictly read-only over the store.** The server never writes to the run store; it only reads and streams what the harness itself produces.
 
 ## Run
 
-- Double-click `start.cmd` (starts the server and opens the browser), or
-- `node server.mjs` from this directory.
+- **Windows:** double-click `start.cmd` (starts the server and opens the browser), or
+- **macOS:** `./start.sh`, or
+- `node server.mjs` from this directory on either platform.
 
-Note that `start.cmd` runs the server in the foreground: closing that console window stops it. For
-an always-on instance use the Scheduled Task below.
+Note that `start.cmd` / `start.sh` run the server in the foreground: closing that terminal
+stops it. For an always-on instance use the platform service below (Scheduled Task on
+Windows, LaunchAgent on macOS).
 
-## Always on (AlbertConsole Scheduled Task)
+## Always on (Windows: AlbertConsole Scheduled Task)
 
 A Scheduled Task named `AlbertConsole` keeps the server up permanently at
 `http://127.0.0.1:4400`. It runs `run-hidden.vbs`, which launches node with no console window.
@@ -67,13 +71,30 @@ Use one mechanism or the other, not both (the loser of the port race would burn 
 retries at every logon). `stop.cmd` handles both: it disables the task if present, kills any
 run-forever supervisor, then kills the port owner.
 
+## Always on (macOS: LaunchAgent)
+
+`install.sh` registers a LaunchAgent named `com.albert.console` that runs
+`node server.mjs` from the installed console directory under
+`~/Library/Application Support/AlbertConsole`, with `KeepAlive` so a crash self-heals.
+Logs go to `console.stdout.log` / `console.stderr.log` next to `server.mjs`.
+
+```
+./restart.sh       # after changing server.mjs, lib/ or public/
+./stop.sh          # unload the agent, then kill the port owner
+./start.sh         # foreground only (does not re-register the agent)
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.albert.console.plist
+launchctl kickstart -k gui/$(id -u)/com.albert.console
+```
+
+Unload before killing the port owner: otherwise KeepAlive brings the server back.
+
 ## Flags
 
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `--port N` | `4400` | HTTP listen port on 127.0.0.1 |
-| `--store <path>` | `%USERPROFILE%\.claude\agent-runs` | Run store root |
-| `--agents <path>` | `%USERPROFILE%\.claude\agents` | Agent definitions dir (`loop-*.md`) |
+| `--store <path>` | `~/.claude/agent-runs` | Run store root |
+| `--agents <path>` | `~/.claude/agents` | Agent definitions dir (`loop-*.md`) |
 
 ## Views
 
@@ -88,7 +109,7 @@ run-forever supervisor, then kills the port owner.
 
 ## Claude Code session tracking
 
-The console tails Claude Code's own transcripts under `%USERPROFILE%\.claude\projects\` (no hooks,
+The console tails Claude Code's own transcripts under `~/.claude/projects/` (no hooks,
 no config, zero added latency, and retroactive over existing sessions). It backfills at boot then
 tails from stored byte offsets.
 

--- a/console/restart.sh
+++ b/console/restart.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Restart the Albert Console (use this after changing server.mjs, lib/, or public/).
+# Unloads KeepAlive briefly is unnecessary if we kickstart -k; kill the port owner
+# first so the next bind succeeds, then restart the LaunchAgent (or start.sh fallback).
+set -euo pipefail
+
+LAUNCH_LABEL="com.albert.console"
+PORT=4400
+uid="$(id -u)"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+if [[ -n "$pids" ]]; then
+  echo "stopping node PID(s) $pids"
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  sleep 0.5
+  pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill -9 $pids 2>/dev/null || true
+  fi
+else
+  echo "nothing listening on $PORT"
+fi
+
+sleep 1
+
+plist="${HOME}/Library/LaunchAgents/${LAUNCH_LABEL}.plist"
+if [[ -f "$plist" ]]; then
+  launchctl bootout "gui/${uid}/${LAUNCH_LABEL}" 2>/dev/null || true
+  launchctl bootstrap "gui/${uid}" "$plist"
+  launchctl kickstart -k "gui/${uid}/${LAUNCH_LABEL}" 2>/dev/null || \
+    launchctl start "$LAUNCH_LABEL" 2>/dev/null || true
+  sleep 2
+  pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    echo "restarted: node PID $pids -> http://127.0.0.1:4400/"
+  else
+    echo "FAILED to come up. Check: launchctl print gui/${uid}/${LAUNCH_LABEL}"
+    echo "Logs: $DIR/console.stderr.log"
+  fi
+else
+  echo "no LaunchAgent registered; starting in background via nohup"
+  nohup node "$DIR/server.mjs" >>"$DIR/console.stdout.log" 2>>"$DIR/console.stderr.log" &
+  echo "started PID $! -> http://127.0.0.1:4400/"
+fi

--- a/console/start.sh
+++ b/console/start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Start the Albert Console in the foreground and open the browser.
+# Closing this terminal stops the server (use the LaunchAgent for always-on).
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+if command -v open >/dev/null 2>&1; then
+  (sleep 1; open "http://127.0.0.1:4400/") &
+elif command -v xdg-open >/dev/null 2>&1; then
+  (sleep 1; xdg-open "http://127.0.0.1:4400/") &
+fi
+exec node "$DIR/server.mjs" "$@"

--- a/console/stop.sh
+++ b/console/stop.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Stop the Albert Console for good: unload the LaunchAgent first (so KeepAlive cannot
+# revive it), then kill whatever still owns port 4400.
+set -euo pipefail
+
+LAUNCH_LABEL="com.albert.console"
+PORT=4400
+uid="$(id -u)"
+
+if launchctl print "gui/${uid}/${LAUNCH_LABEL}" >/dev/null 2>&1; then
+  launchctl bootout "gui/${uid}/${LAUNCH_LABEL}" 2>/dev/null || true
+  echo "LaunchAgent ${LAUNCH_LABEL} unloaded. Re-enable with: launchctl bootstrap gui/${uid} ~/Library/LaunchAgents/${LAUNCH_LABEL}.plist"
+elif [[ -f "${HOME}/Library/LaunchAgents/${LAUNCH_LABEL}.plist" ]]; then
+  launchctl unload "${HOME}/Library/LaunchAgents/${LAUNCH_LABEL}.plist" 2>/dev/null || true
+  echo "LaunchAgent ${LAUNCH_LABEL} unloaded"
+fi
+
+pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+if [[ -n "$pids" ]]; then
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  sleep 0.3
+  pids="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill -9 $pids 2>/dev/null || true
+  fi
+  echo "server stopped"
+else
+  echo "server was not running"
+fi

--- a/install.ps1
+++ b/install.ps1
@@ -164,4 +164,5 @@ Step "Installed."
 Write-Host "  Run a goal from any project:  " -NoNewline; Write-Host '/albert "<your goal>"' -ForegroundColor White
 if (-not $NoConsole -and -not $NoTask) { Write-Host "  Watch it live:                http://localhost:4400" }
 Write-Host "  Chat UI (optional):           see chat\README.md (requires Python 3.12)"
-Write-Host "  Remove everything:            .\uninstall.ps1`n"
+Write-Host "  Remove everything:            .\uninstall.ps1"
+Write-Host "  macOS users:                  use .\install.sh instead`n"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Installs the Albert harness and the Albert Console on macOS (and other Unix).
+# Mirrors install.ps1: same files, same {{TOKEN}} resolution, optional always-on
+# LaunchAgent instead of a Windows Scheduled Task.
+#
+# Usage:
+#   ./install.sh
+#   ./install.sh --demo-only
+#   ./install.sh --no-console
+#   ./install.sh --no-task
+#   ./install.sh --claude-dir DIR --projects-dir DIR --console-dir DIR --port N
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_DIR="${HOME}/.claude"
+PROJECTS_DIR="$(dirname "$REPO")"
+CONSOLE_DIR="${HOME}/Library/Application Support/AlbertConsole"
+PORT=4400
+DEMO_ONLY=0
+NO_CONSOLE=0
+NO_TASK=0
+LAUNCH_LABEL="com.albert.console"
+
+info() { printf '  %s\n' "$*"; }
+ok()   { printf '  [ok] %s\n' "$*"; }
+warn() { printf '  [!] %s\n' "$*"; }
+step() { printf '\n%s\n' "$*"; }
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --claude-dir)   CLAUDE_DIR="$2"; shift 2 ;;
+    --projects-dir) PROJECTS_DIR="$2"; shift 2 ;;
+    --console-dir)  CONSOLE_DIR="$2"; shift 2 ;;
+    --port)         PORT="$2"; shift 2 ;;
+    --demo-only)    DEMO_ONLY=1; shift ;;
+    --no-console)   NO_CONSOLE=1; shift ;;
+    --no-task)      NO_TASK=1; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v node >/dev/null 2>&1 || die "Node.js is not on PATH. Install Node 20+ (26 recommended) and re-run."
+
+# Resolve {{CLAUDE_DIR}} / {{PROJECTS_DIR}} / {{CONSOLE_DIR}}. On Unix paths use '/', so
+# the JS-escape pass is a no-op unless a path somehow contains a backslash.
+install_file() {
+  local src="$1" dst="$2" js_escape="${3:-0}"
+  local claude="$CLAUDE_DIR" projects="$PROJECTS_DIR" console="$CONSOLE_DIR"
+  if [[ "$js_escape" == "1" ]]; then
+    claude="${claude//\\/\\\\}"
+    projects="${projects//\\/\\\\}"
+    console="${console//\\/\\\\}"
+  fi
+  mkdir -p "$(dirname "$dst")"
+  # Prefer python3 for reliable UTF-8 rewrite; fall back to sed.
+  if command -v python3 >/dev/null 2>&1; then
+    CLAUDE="$claude" PROJECTS="$projects" CONSOLE="$console" python3 - "$src" "$dst" <<'PY'
+import os, sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src, encoding="utf-8").read()
+text = (text
+  .replace("{{CLAUDE_DIR}}", os.environ["CLAUDE"])
+  .replace("{{PROJECTS_DIR}}", os.environ["PROJECTS"])
+  .replace("{{CONSOLE_DIR}}", os.environ["CONSOLE"]))
+open(dst, "w", encoding="utf-8", newline="\n").write(text)
+PY
+  else
+    sed -e "s|{{CLAUDE_DIR}}|${claude}|g" \
+        -e "s|{{PROJECTS_DIR}}|${projects}|g" \
+        -e "s|{{CONSOLE_DIR}}|${console}|g" \
+        "$src" > "$dst"
+  fi
+}
+
+if [[ "$DEMO_ONLY" -eq 1 ]]; then
+  step "Generating synthetic demo data"
+  demo_dir="$REPO/tools/demo-out"
+  node "$REPO/tools/make-demo-data.mjs" "$demo_dir"
+  ok "demo data at $demo_dir"
+  step "Starting the console at http://localhost:${PORT}  (Ctrl+C to stop)"
+  if command -v open >/dev/null 2>&1; then
+    (sleep 1; open "http://localhost:${PORT}") &
+  fi
+  exec node "$REPO/console/server.mjs" \
+    --port "$PORT" \
+    --store "$demo_dir/agent-runs" \
+    --projects "$demo_dir/projects" \
+    --agents "$REPO/harness/agents"
+fi
+
+printf '\nInstalling Albert\n'
+info "ClaudeDir   : $CLAUDE_DIR"
+info "ProjectsDir : $PROJECTS_DIR"
+info "ConsoleDir  : $CONSOLE_DIR"
+
+step "Installing harness into Claude Code config"
+
+install_file "$REPO/harness/skills/albert/SKILL.md" "$CLAUDE_DIR/skills/albert/SKILL.md"
+ok "skill: /albert"
+
+generic_deps="code-reviewer security-reviewer performance-reviewer doc-writer refactor-worker codebase-locator"
+skipped_deps=()
+for f in "$REPO"/harness/agents/*.md; do
+  name="$(basename "$f" .md)"
+  dst="$CLAUDE_DIR/agents/$(basename "$f")"
+  skip=0
+  for g in $generic_deps; do
+    if [[ "$name" == "$g" && -f "$dst" ]]; then
+      skipped_deps+=("$name")
+      skip=1
+      break
+    fi
+  done
+  [[ "$skip" -eq 1 ]] && continue
+  install_file "$f" "$dst"
+done
+ok "agents: 11 loop-* roster + generic helpers"
+if [[ ${#skipped_deps[@]} -gt 0 ]]; then
+  info "kept your existing helper agents: ${skipped_deps[*]}"
+fi
+
+install_file "$REPO/harness/workflows/chunk-exec.js" "$CLAUDE_DIR/workflows/chunk-exec.js" 1
+ok "workflow: chunk-exec (parallel executor)"
+
+install_file "$REPO/harness/runtime/_emit.mjs" "$CLAUDE_DIR/agent-runs/_emit.mjs"
+install_file "$REPO/harness/runtime/_inbox.mjs" "$CLAUDE_DIR/agent-runs/_inbox.mjs"
+install_file "$REPO/harness/runtime/agent-runs-README.md" "$CLAUDE_DIR/agent-runs/README.md"
+ok "run store: _emit.mjs + _inbox.mjs + README (existing run data left untouched)"
+
+if [[ "$NO_CONSOLE" -eq 0 ]]; then
+  step "Installing Albert Console"
+  while IFS= read -r -d '' f; do
+    rel="${f#"$REPO/console/"}"
+    install_file "$f" "$CONSOLE_DIR/$rel"
+  done < <(find "$REPO/console" -type f -print0)
+  chmod +x "$CONSOLE_DIR/start.sh" "$CONSOLE_DIR/stop.sh" 2>/dev/null || true
+  ok "console installed at $CONSOLE_DIR"
+
+  if [[ "$NO_TASK" -eq 0 ]]; then
+    node_bin="$(command -v node)"
+    plist_dir="${HOME}/Library/LaunchAgents"
+    plist_path="${plist_dir}/${LAUNCH_LABEL}.plist"
+    mkdir -p "$plist_dir"
+    cat > "$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCH_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${node_bin}</string>
+    <string>${CONSOLE_DIR}/server.mjs</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${CONSOLE_DIR}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${CONSOLE_DIR}/console.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>${CONSOLE_DIR}/console.stderr.log</string>
+</dict>
+</plist>
+EOF
+    launchctl bootout "gui/$(id -u)/${LAUNCH_LABEL}" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$plist_path"
+    launchctl enable "gui/$(id -u)/${LAUNCH_LABEL}" 2>/dev/null || true
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCH_LABEL}" 2>/dev/null || \
+      launchctl start "$LAUNCH_LABEL" 2>/dev/null || true
+    ok "registered LaunchAgent '${LAUNCH_LABEL}' -> http://localhost:4400"
+  else
+    info "console agent not registered (--no-task). Start it with: ${CONSOLE_DIR}/start.sh"
+  fi
+fi
+
+step "Installed."
+printf '  Run a goal from any project:  '
+printf '/albert "<your goal>"\n'
+if [[ "$NO_CONSOLE" -eq 0 && "$NO_TASK" -eq 0 ]]; then
+  printf '  Watch it live:                http://localhost:4400\n'
+fi
+printf '  Chat UI (optional):           see chat/README.md (requires Python 3.12)\n'
+printf '  Remove everything:            ./uninstall.sh\n\n'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Removes the Albert harness and the Albert Console from this machine.
+# Mirrors uninstall.ps1 for macOS (LaunchAgent instead of Scheduled Task).
+#
+# Usage:
+#   ./uninstall.sh
+#   ./uninstall.sh --claude-dir DIR --console-dir DIR
+set -euo pipefail
+
+CLAUDE_DIR="${HOME}/.claude"
+CONSOLE_DIR="${HOME}/Library/Application Support/AlbertConsole"
+PORT=4400
+CHAT_PORT=4401
+LAUNCH_LABEL="com.albert.console"
+
+info() { printf '  %s\n' "$*"; }
+ok()   { printf '  [ok] %s\n' "$*"; }
+warn() { printf '  [!] %s\n' "$*"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --claude-dir)  CLAUDE_DIR="$2"; shift 2 ;;
+    --console-dir) CONSOLE_DIR="$2"; shift 2 ;;
+    --port)        PORT="$2"; shift 2 ;;
+    --chat-port)   CHAT_PORT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    *) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+printf '\nRemoving Albert\n'
+info "ClaudeDir  : $CLAUDE_DIR"
+info "ConsoleDir : $CONSOLE_DIR"
+printf '\n'
+
+# 1. LaunchAgent + port owners -------------------------------------------------------------
+plist_path="${HOME}/Library/LaunchAgents/${LAUNCH_LABEL}.plist"
+if [[ -f "$plist_path" ]] || launchctl print "gui/$(id -u)/${LAUNCH_LABEL}" >/dev/null 2>&1; then
+  launchctl bootout "gui/$(id -u)/${LAUNCH_LABEL}" 2>/dev/null || \
+    launchctl unload "$plist_path" 2>/dev/null || true
+  rm -f "$plist_path"
+  ok "unregistered LaunchAgent ${LAUNCH_LABEL}"
+else
+  info "no ${LAUNCH_LABEL} LaunchAgent registered"
+fi
+
+# Kill anything still listening on the console/chat ports (orphans after unload).
+free_port() {
+  local p="$1"
+  local pids
+  pids="$(lsof -nP -iTCP:"$p" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -z "$pids" ]]; then
+    info "nothing listening on port $p"
+    return
+  fi
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  sleep 0.3
+  pids="$(lsof -nP -iTCP:"$p" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill -9 $pids 2>/dev/null || true
+  fi
+  ok "freed port $p"
+}
+free_port "$PORT"
+free_port "$CHAT_PORT"
+
+# 2. Console install copy -------------------------------------------------------------------
+if [[ -d "$CONSOLE_DIR" ]]; then
+  rm -rf "$CONSOLE_DIR"
+  ok "removed console at $CONSOLE_DIR"
+else
+  info "no console install found at $CONSOLE_DIR"
+fi
+
+# 3. Harness files we own -------------------------------------------------------------------
+loop_agents=(
+  loop-planner loop-worker loop-data-scientist loop-designer loop-researcher
+  loop-devops loop-verifier-dev loop-qa loop-skeptic-research loop-cleanup loop-scribe
+)
+owned_paths=(
+  "$CLAUDE_DIR/skills/albert"
+  "$CLAUDE_DIR/workflows/chunk-exec.js"
+  "$CLAUDE_DIR/agent-runs/_emit.mjs"
+  "$CLAUDE_DIR/agent-runs/_inbox.mjs"
+)
+for a in "${loop_agents[@]}"; do
+  owned_paths+=("$CLAUDE_DIR/agents/${a}.md")
+done
+
+for p in "${owned_paths[@]}"; do
+  if [[ -e "$p" ]]; then
+    rm -rf "$p"
+    ok "removed $p"
+  fi
+done
+
+# 4. What we intentionally left ------------------------------------------------------------
+generic_deps=(code-reviewer security-reviewer performance-reviewer doc-writer refactor-worker codebase-locator)
+left_deps=()
+for g in "${generic_deps[@]}"; do
+  [[ -f "$CLAUDE_DIR/agents/${g}.md" ]] && left_deps+=("$g")
+done
+if [[ ${#left_deps[@]} -gt 0 ]]; then
+  warn "left generic helper agents in place (remove by hand if unwanted): ${left_deps[*]}"
+fi
+run_store="$CLAUDE_DIR/agent-runs"
+if [[ -d "$run_store" ]] && find "$run_store" -mindepth 1 -maxdepth 1 -type d | grep -q .; then
+  warn "left your run history under $run_store (delete manually to erase it)"
+fi
+
+printf '\nDone.\n\n'


### PR DESCRIPTION
Adds full macOS/Unix-like support to the project alongside the existing Windows setup.

Key Changes:

Added native bash scripts for installation (install.sh, uninstall.sh) and workspace launchers (launch_run.sh).
Added lifecycle scripts (start.sh, stop.sh, restart.sh) for both the Chat UI and the Console on macOS.
Updated chat/albert_tools.py and chat/config.py to dynamically execute PowerShell on Windows and Bash on macOS.
Updated READMEs and contributing guidelines with macOS setup and run instructions.