### PR TITLE
fix(chat): work when the console is not on localhost

### DIFF
--- a/chat/server.py
+++ b/chat/server.py
@@ -36,12 +36,19 @@ PORT = os.environ.get("ALBERT_CHAT_PORT", "4401")
 # Only this service's own origins. The console embeds the chat in an iframe, and an
 # iframe's requests carry the IFRAME's origin (this service), not the console's, so
 # the console's port does not belong here.
+#
+# ALBERT_CHAT_ORIGINS (comma-separated) adds the origins this service answers on when it
+# is fronted by a reverse proxy. On a headless Linux box the browser is never on
+# localhost, so the iframe's origin is the proxy's (e.g. a Tailscale Serve HTTPS origin
+# on this same port) and the localhost entries below never match. This still names exact
+# origins, so a drive-by page is rejected exactly as before.
 ALLOWED_ORIGINS = frozenset(
     {
         f"http://127.0.0.1:{PORT}",
         f"http://localhost:{PORT}",
         f"http://[::1]:{PORT}",
     }
+    | {o.strip() for o in os.environ.get("ALBERT_CHAT_ORIGINS", "").split(",") if o.strip()}
 )
 
 

--- a/console/public/app.js
+++ b/console/public/app.js
@@ -3422,7 +3422,10 @@ function setView(v) {
 // active and only toggles CSS classes, never detaching the iframe: the websocket and the
 // conversation survive closing and reopening it. The src is set lazily on first open, so
 // the console never touches 4401 unless the dock is used.
-const CHAT_URL = 'http://127.0.0.1:4401/';
+// Derived from the console's own origin rather than hardcoded to 127.0.0.1: on a headless
+// box the browser is remote, so localhost would be the VIEWER's machine. The chat sits on
+// the next port up, reached over whatever scheme/host got you to the console.
+const CHAT_URL = `${location.protocol}//${location.hostname}:4401/`;
 let chatLoaded = false;
 
 function ensureChat() {
@@ -3458,6 +3461,8 @@ function toggleChat(force) {
 }
 
 function wireChat() {
+  const pop = $('#chatPop');
+  if (pop) pop.href = CHAT_URL; // same derivation as the iframe, not a hardcoded localhost
   const btn = $('#chatBtn');
   if (btn) btn.addEventListener('click', () => toggleChat());
   const close = $('#chatClose');

--- a/console/public/index.html
+++ b/console/public/index.html
@@ -114,7 +114,7 @@
   <i class="c4" aria-hidden="true"></i>
   <div class="chat-dock-head">
     <span class="chat-dock-title">A.L.B.E.R.T. DIRECT LINE</span>
-    <a class="chat-dock-pop" href="http://127.0.0.1:4401/" target="_blank" rel="noopener">FULL</a>
+    <a class="chat-dock-pop" id="chatPop" target="_blank" rel="noopener">FULL</a>
     <button id="chatClose" type="button" aria-label="Close chat">CLOSE</button>
   </div>
   <div class="chat-dock-body">


### PR DESCRIPTION
Two hardcoded localhost assumptions make the chat dock unusable whenever you are not browsing from the machine Albert runs on. I hit this installing Albert on a headless Linux box and reaching the console over a Tailscale HTTPS proxy, but it applies equally to a Windows desktop you reach from a laptop, or a VM.

Both changes are Windows-path-safe. On a browser running on the same machine the new derivation still resolves to `127.0.0.1:4401`, and `ALBERT_CHAT_ORIGINS` defaults to empty, so today's behavior is unchanged.

### 1. `CHAT_URL` is evaluated in the browser, not on the server

`console/public/app.js` had `const CHAT_URL = 'http://127.0.0.1:4401/'`. That literal runs in the **viewer's** browser, so from any other machine it points at the viewer's own localhost. The dock reports `ALBERT CHAT OFFLINE` no matter what is running on the server, which reads as "chat is broken" rather than "that URL is not reachable from here".

Now derived from the console's own origin: `${location.protocol}//${location.hostname}:4401/`. The `FULL` popout link carried the same literal, so it moves to an id that gets the same value.

### 2. The OriginGuard refuses the iframe's own origin behind a proxy

`chat/server.py` builds `ALLOWED_ORIGINS` purely from localhost forms. Behind any reverse proxy, the iframe's own origin is the proxy's, so every socket.io handshake is closed with code 1008 and the dock renders an empty Chainlit shell that never connects. Nothing in the UI says why.

Added `ALBERT_CHAT_ORIGINS` (comma-separated) which merges into the same frozenset. This deliberately keeps the guard an exact-match allowlist rather than relaxing it to a pattern, so the cross-site WebSocket hijacking property described in your module docstring is preserved. Verified on my install:

| Request | Origin | Result |
|---|---|---|
| `GET /ws/socket.io/?EIO=4&transport=polling` | the iframe's real origin | 200 + session id |
| same | `https://evil.example` | **403** |
| same | the console's own origin (`:4400`) | **403** |

That last row is intentional and unchanged: the console's health probe is `fetch(CHAT_URL, {mode: 'no-cors'})`, which resolves on any response and only rejects when nothing is listening, so a 403 still correctly reads as "up". The console's port stays out of the allowlist, per the comment already in that file.

### Checks

- `node --check console/public/app.js` passes; `chat/server.py` compiles.
- Ran the patched console and chat, confirmed the dock loads, the concierge answers, and the Comms view still renders.
- No em or en dashes in the added prose or comments.
- **One gap, disclosed:** I could not run the `install.ps1 -ClaudeDir <scratch> -NoConsole` step from CONTRIBUTING.md, because this box has no PowerShell. That check covers template-token resolution, and this PR touches no `{{TOKEN}}` templates (only `chat/server.py` and two console assets, none of which the installer rewrites beyond a straight copy), so I believe it is not implicated. Happy to have you verify that one.

Separately, I ran into several other Linux-install issues that are bigger than this patch and are design calls that belong to you, not unsolicited PRs. Filing those as an issue rather than folding them in here.
