### PR TITLE
fix(chat): launch runs on POSIX instead of shelling to powershell

### DIFF
--- a/chat/albert_tools.py
+++ b/chat/albert_tools.py
@@ -2,13 +2,16 @@
 
 Both tools shell out rather than touching the store from Python: send_to_albert goes
 through _inbox.mjs (which owns the NTFS write discipline), and start_albert_run goes
-through launch_run.ps1 (which owns .cmd resolution and detached-window quoting).
+through launch_run.ps1 on Windows (which owns .cmd resolution and detached-window
+quoting) or a detached tmux session on POSIX. See _launch_cmd.
 """
 
 import asyncio
 import os
 import re
+import shutil
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -68,6 +71,60 @@ def _run(cmd: list[str], env: dict | None = None) -> subprocess.CompletedProcess
         timeout=60,
         env=env,
         creationflags=NO_WINDOW,
+    )
+
+
+class LaunchUnavailable(Exception):
+    """This platform has no usable way to start a detached, attachable run."""
+
+
+def _launch_cmd(project: Path, prompt: str) -> tuple[list[str], str]:
+    """argv that starts a detached /albert session, plus how to watch it.
+
+    Windows goes through launch_run.ps1, which owns .cmd shim resolution and
+    Start-Process quoting. POSIX has neither a .cmd shim nor a console window to
+    start, and a detached `claude` with no controlling terminal exits instead of
+    opening a session, so the run needs a pty that outlives this chat process.
+    tmux is that pty, and `tmux attach` is the closest equivalent to the Windows
+    window: visible, and survives the chat exiting.
+
+    Passing the command as separate argv words keeps any shell out of the path.
+    Verified against tmux 3.2a that $VAR, backticks and semicolons reach the child
+    literally, so nothing re-parses the goal the way cmd.exe does on Windows.
+    """
+    if os.name == "nt":
+        return (
+            [
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(LAUNCH_PS1),
+                "-Project",
+                str(project),
+                "-Prompt",
+                prompt,
+            ],
+            "in a new console window",
+        )
+
+    tmux = shutil.which("tmux")
+    if not tmux:
+        raise LaunchUnavailable(
+            "tmux is not installed. On Linux and macOS it is what gives the run a "
+            "terminal that outlives this chat, so the launcher needs it. Install it "
+            "(apt install tmux / brew install tmux) and ask me again."
+        )
+    claude = shutil.which("claude")
+    if not claude:
+        raise LaunchUnavailable("claude CLI not found on PATH.")
+
+    # Second-resolution suffix so two runs in one project do not collide on the name.
+    session = f"albert-{project.name}-{time.strftime('%H%M%S')}"
+    return (
+        [tmux, "new-session", "-d", "-s", session, "-c", str(project), claude, prompt],
+        f"in tmux session {session} (watch it with: tmux attach -t {session})",
     )
 
 
@@ -203,18 +260,10 @@ def make_albert_server(state: SessionState):
         if not goal:
             return _text("goal became empty after removing unsafe characters.", is_error=True)
         prompt = f"/loop /albert {goal}"
-        cmd = [
-            "powershell",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            str(LAUNCH_PS1),
-            "-Project",
-            str(project),
-            "-Prompt",
-            prompt,
-        ]
+        try:
+            cmd, where = _launch_cmd(project, prompt)
+        except LaunchUnavailable as e:
+            return _text(str(e), is_error=True)
         try:
             proc = await asyncio.to_thread(_run, cmd)
         except (OSError, subprocess.TimeoutExpired) as e:
@@ -223,9 +272,9 @@ def make_albert_server(state: SessionState):
             return _text(f"launch failed: {proc.stderr.strip()}", is_error=True)
 
         return _text(
-            f"Launched /albert in a new console window for {project.name} with goal: "
-            f"{goal}. It registers itself in the run store shortly; watch it live at "
-            "http://127.0.0.1:4400."
+            f"Launched /albert {where} for {project.name} with goal: {goal}. It "
+            "registers itself in the run store shortly; watch it live in the console "
+            "on port 4400."
         )
 
     return create_sdk_mcp_server(


### PR DESCRIPTION
`start_albert_run` builds a `powershell -File launch_run.ps1` command line unconditionally, with no platform branch, so on Linux and macOS the tool fails with:

```
could not launch the run: [Errno 2] No such file or directory: 'powershell'
```

It cannot open a run at all there, whatever the project or goal. The failure is at least clean: it happens before any store write, so there is no `index.json`, no run directory, and no partial state to reap.

This is the `chat/albert_tools.py` item from #4, split out because it is self-contained and does not depend on the design calls in that issue. The `init.ps1` bootstrap discussed there is still a separate wall a launched run will hit; this PR only fixes the launcher.

### Windows is unchanged

`launch_run.ps1` is untouched and still owns `.cmd` shim resolution and `Start-Process` quoting. The `os.name == "nt"` branch produces the identical argv it did before, so there is no new Windows code path to regress.

### Why tmux on POSIX rather than a launch_run.sh

Neither problem `launch_run.ps1` solves applies: there is no npm `.cmd` shim, and `subprocess` takes argv directly so nothing needs quoting. A different problem does apply, and a plain `subprocess.Popen(..., start_new_session=True)` does not survive it: a detached `claude` with no controlling terminal exits instead of opening a session.

tmux supplies the pty, keeps the run alive after the chat process goes away, and `tmux attach -t <session>` gives the operator the visible window that `Start-Process` gives on Windows. Session name is `albert-<project>-<HHMMSS>`, the suffix so two runs in one project cannot collide on the name. A missing tmux is reported as a fixable precondition ("install it and ask me again") rather than surfacing a traceback to the concierge.

### No shell re-parse

The command goes to tmux as separate argv words. Verified against tmux 3.2a that `$VAR`, backticks and `;` all reach the child literally, so the cmd.exe second-parse problem your `CMD_METACHARACTERS` comment describes has no POSIX analogue here.

I still left that scrub applying on both platforms. POSIX does not need it, and it costs a few characters of goal text, but one sanitizing path is safer to maintain than two conditional ones. Say the word if you would rather it be Windows-only and I will gate it.

### Also

Dropped the hardcoded `http://127.0.0.1:4400` from the success message, since the console is frequently not on the viewer's own localhost. Same reasoning as #3, which fixes that class of bug in the console assets.

### Checks

- `chat/albert_tools.py` compiles; `_launch_cmd` asserted to contain no `powershell` on this box.
- Confirmed a detached tmux session starts in the right cwd, survives the launching process exiting, and that `claude` runs correctly under a pty.
- Windows branch verified by inspection only, since this box has no PowerShell. Same disclosure as #3: I cannot run the `install.ps1` scratch-dir check from CONTRIBUTING.md, though this PR touches no `{{TOKEN}}` templates.
- **I have not completed a full `/albert` run through this path**, so the claim is specifically that the launcher now launches, not that a POSIX run completes. #4 item 3 is the next wall.
- No em or en dashes in the added prose or comments.
